### PR TITLE
🔧 feat(workflows): add multiple daily schedules for security news

### DIFF
--- a/.github/workflows/fetch-security-news.yml
+++ b/.github/workflows/fetch-security-news.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # 毎日午前9時（JST）に実行 = UTC 0時
     - cron: "0 0 * * *"
+    # 毎日午後3時（JST）に実行 = UTC 6時
+    - cron: "0 6 * * *"
+    # 毎日午後9時（JST）に実行 = UTC 12時
+    - cron: "0 12 * * *"
   workflow_dispatch: # 手動実行も可能
 
 jobs:

--- a/scripts/fetch-security-news.mjs
+++ b/scripts/fetch-security-news.mjs
@@ -120,7 +120,8 @@ async function generateArticleWithClaude(item) {
 
 // MDXファイル生成
 async function generateMDXFile(article, originalItem) {
-  const date = new Date(originalItem.pubDate || Date.now());
+  // ブログ記事の公開日は生成日（今日）を使用
+  const date = new Date();
   const dateStr = date.toISOString().slice(0, 10).replace(/-/g, "/");
   const fileDate = date.toISOString().slice(0, 10);
 


### PR DESCRIPTION
- Add 3PM JST (UTC 6:00) and 9PM JST (UTC 12:00) cron schedules
- Change blog post date from RSS pubDate to current generation date
- Ensure consistent daily content with multiple fetch intervals